### PR TITLE
Fix Capitalization on setUpControl for Chromium

### DIFF
--- a/js/webm-settings.js
+++ b/js/webm-settings.js
@@ -68,7 +68,7 @@ function refreshSettings_webm() {
     }
 }
 
-function setupControl_webm(control) {
+function setUpControl_webm(control) {
     if (control.addEventListener) control.addEventListener("change", function(e) {
         if (control.type == "checkbox") {
             changeSetting_webm(control.name, control.checked);
@@ -81,7 +81,7 @@ function setupControl_webm(control) {
 refreshSettings_webm();
 var settingsItems_webm = settingsMenu_webm.getElementsByTagName("input");
 for (var i = 0; i < settingsItems_webm.length; i++) {
-    setupControl(settingsItems_webm[i]);
+    setUpControl(settingsItems_webm[i]);
 }
 
 if (settingsMenu_webm.addEventListener && !window.Options) {


### PR DESCRIPTION
Chromium browsers expect capital U in setUpControl and old version of webm-settings.js has setupControl which causes a error and makes expand-video.js not work and options.js not save when this is in use. This bug is not present on FireFox which automatically fixes this for some reason. Stupid bug, stupid fix. No lines actually added or removed.